### PR TITLE
Add regex options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,7 +78,11 @@ try{
 
     // Like operator
     rsqlMongoDB('lastName=~do*');
-    //=> { "lastName": { $regex: "do*" } }
+    //=> { "lastName": { $regex: "do*", $options: "" } }
+
+    // Like operator with options
+    rsqlMongoDB('lastName=~do*=si');
+    //=> { "lastName": { $regex: "do*", $options: "si" } }
 
     // Exists operator
     rsqlMongoDB('childs=exists=true');

--- a/Readme.md
+++ b/Readme.md
@@ -83,6 +83,8 @@ try{
     // Like operator with options
     rsqlMongoDB('lastName=~do*=si');
     //=> { "lastName": { $regex: "do*", $options: "si" } }
+    rsqlMongoDB('lastName=~"do=*"=si');
+    //=> { "lastName": { $regex: "do=*", $options: "si" } }
 
     // Exists operator
     rsqlMongoDB('childs=exists=true');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsql-mongodb",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Converting RSQL queries to MongoDB queries",
   "main": "rsql-mongodb.js",
   "typings": "rsql-mongodb.ts",

--- a/rsql-mongodb.js
+++ b/rsql-mongodb.js
@@ -248,7 +248,8 @@ module.exports = function (input) {
 					mongoOperatorQuery[exp1] = { $nin: typedValues };
 					break;
 				case "=~":
-					mongoOperatorQuery[exp1] = { $regex: typedExp2 };
+					const typedExp2Arr = typedExp2.split("=");
+					mongoOperatorQuery[exp1] = { $regex: typedExp2Arr[0], $options: typedExp2Arr[1] || "" };
 					break;
 				case "=exists=":
 					mongoOperatorQuery[exp1] = { $exists: typedExp2 };

--- a/rsql-mongodb.js
+++ b/rsql-mongodb.js
@@ -248,8 +248,8 @@ module.exports = function (input) {
 					mongoOperatorQuery[exp1] = { $nin: typedValues };
 					break;
 				case "=~":
-					const typedExp2Arr = typedExp2.split("=");
-					mongoOperatorQuery[exp1] = { $regex: typedExp2Arr[0], $options: typedExp2Arr[1] || "" };
+					var expArr = exp2.split(/(=)(?=(?:[^"]|"[^"]*")*$)/g);
+					mongoOperatorQuery[exp1] = { $regex: setType(expArr[0]), $options: expArr[2] || "" };
 					break;
 				case "=exists=":
 					mongoOperatorQuery[exp1] = { $exists: typedExp2 };

--- a/test.js
+++ b/test.js
@@ -56,6 +56,7 @@ describe('rsql-mongodb', function () {
         expect(rsqlMongoDB('lastName=~do*')).to.deep.include({ "lastName": { $regex: "do*", $options: "" } });
         expect(rsqlMongoDB('lastName=~do*=i')).to.deep.include({ "lastName": { $regex: "do*", $options: "i" } });
         expect(rsqlMongoDB('lastName=~do*=mxs')).to.deep.include({ "lastName": { $regex: "do*", $options: "mxs" } });
+        expect(rsqlMongoDB('lastName=~"do=*"=mxs')).to.deep.include({ "lastName": { $regex: "do=*", $options: "mxs" } });
     });
     it("Test operator Exists ('=exists=')", function () {
         expect(rsqlMongoDB('childs=exists=true')).to.deep.include({ "childs": { $exists: true } });

--- a/test.js
+++ b/test.js
@@ -53,13 +53,14 @@ describe('rsql-mongodb', function () {
         expect(rsqlMongoDB('childs=out=(1, 2, 3 )')).to.deep.include({ "childs": { $nin: [1,2,3] } });
     });
     it("Test operator Like ('=~')", function () {
-        expect(rsqlMongoDB('lastName=~do*')).to.deep.include({ "lastName": { $regex: "do*" } });
+        expect(rsqlMongoDB('lastName=~do*')).to.deep.include({ "lastName": { $regex: "do*", $options: "" } });
+        expect(rsqlMongoDB('lastName=~do*=i')).to.deep.include({ "lastName": { $regex: "do*", $options: "i" } });
+        expect(rsqlMongoDB('lastName=~do*=mxs')).to.deep.include({ "lastName": { $regex: "do*", $options: "mxs" } });
     });
     it("Test operator Exists ('=exists=')", function () {
         expect(rsqlMongoDB('childs=exists=true')).to.deep.include({ "childs": { $exists: true } });
         expect(rsqlMongoDB('childs=exists=false')).to.deep.include({ "childs": { $exists: false } });
         expect(rsqlMongoDB('childs=exists=true')).to.be.a('object');
-
     });
     it("Test logical operator AND (';')", function () {
         expect(rsqlMongoDB('firstName=="john";lastName=="doe"')).to.deep.include({ $and: [ { "firstName" : "john" } , { "lastName" : "doe" } ] });


### PR DESCRIPTION
- Add capabilty to provide regex [options](https://docs.mongodb.com/manual/reference/operator/query/regex/#op._S_options), without usage breaking change.
- Use `=` as separator for identifying the options for the regex.

**Examples**
```javascript
rsqlMongoDB('lastName=~do*') // { $regex: "do*", $options: "" } - empty string options should not have any effects
rsqlMongoDB('lastName=~do*=ix') // { $regex: "do*", $options: "ix" }
```

If there are suggestions for a different separator or a different way of providing options, I would also be happy to hear about it.