### PR TITLE
Add not-regex operator

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,12 @@ try{
     rsqlMongoDB('lastName=regex="do=*"=si');
     //=> { "lastName": { $regex: "do=*", $options: "si" } }
 
+     // Not like operator with options
+    rsqlMongoDB("lastName!=regex=do*=si");
+    //=> { "lastName": { $not: { $regex: "do*", $options: "si" } } }
+    rsqlMongoDB('lastName!=regex="do=*"=si');
+    //=> { "lastName": { $not: { $regex: "do=*", $options: "si" } } }
+
     // Exists operator
     rsqlMongoDB('childs=exists=true');
     //=> { "childs": { $exists: true } }

--- a/Readme.md
+++ b/Readme.md
@@ -87,9 +87,9 @@ try{
     //=> { "lastName": { $regex: "do=*", $options: "si" } }
 
      // Not like operator with options
-    rsqlMongoDB("lastName!=regex=do*=si");
+    rsqlMongoDB("lastName==notregex=do*=si");
     //=> { "lastName": { $not: { $regex: "do*", $options: "si" } } }
-    rsqlMongoDB('lastName!=regex="do=*"=si');
+    rsqlMongoDB('lastName=notregex="do=*"=si');
     //=> { "lastName": { $not: { $regex: "do=*", $options: "si" } } }
 
     // Exists operator

--- a/rsql-mongodb.js
+++ b/rsql-mongodb.js
@@ -264,7 +264,7 @@ module.exports = function (input) {
 			}
 
 			// Split the query
-			var rsqlOperators = /(.*)(==|!=|=gt=|=ge=|=lt=|=le=|=in=|=out=|=regex=|=exists=)(.*)/g;
+			var rsqlOperators = /([^!]*)(!=regex=|=regex=|==|!=|=gt=|=ge=|=lt=|=le=|=in=|=out=|=exists=)(.*)/g;
 			var rsqlQuery = rsqlOperators.exec(outputTab[i]);
 
 			try {
@@ -333,10 +333,20 @@ module.exports = function (input) {
 						mongoOperatorQuery[exp1] = { $nin: typedValues };
 						break;
 					case "=regex=":
-						var expArr = exp2.split(/(=)(?=(?:[^"]|"[^"]*")*$)/g);
-                        const regex = new RegExp(expArr[0]);
-                        regex.test('');
-                        mongoOperatorQuery[exp1] = { $regex: `${setType(expArr[0])}`, $options: expArr[2] || "" };
+						{
+							var expArr = exp2.split(/(=)(?=(?:[^"]|"[^"]*")*$)/g);
+                        	const regex = new RegExp(expArr[0]);
+                        	regex.test('');
+                        	mongoOperatorQuery[exp1] = { $regex: `${setType(expArr[0])}`, $options: expArr[2] || "" };
+						}
+						break;
+					case "!=regex=":
+						{
+							var expArr = exp2.split(/(=)(?=(?:[^"]|"[^"]*")*$)/g);
+                        	const regex = new RegExp(expArr[0]);
+                        	regex.test('');
+                        	mongoOperatorQuery[exp1] = { $not: { $regex: `${setType(expArr[0])}`, $options: expArr[2] || "" } };
+						}
 						break;
 					case "=exists=":
 						mongoOperatorQuery[exp1] = { $exists: typedExp2 };

--- a/rsql-mongodb.js
+++ b/rsql-mongodb.js
@@ -264,7 +264,7 @@ module.exports = function (input) {
 			}
 
 			// Split the query
-			var rsqlOperators = /([^!]*)(!=regex=|=regex=|==|!=|=gt=|=ge=|=lt=|=le=|=in=|=out=|=exists=)(.*)/g;
+			var rsqlOperators = /(.*)(==|!=|=gt=|=ge=|=lt=|=le=|=in=|=out=|=regex=|=notregex=|=exists=)(.*)/g;
 			var rsqlQuery = rsqlOperators.exec(outputTab[i]);
 
 			try {
@@ -340,7 +340,7 @@ module.exports = function (input) {
                         	mongoOperatorQuery[exp1] = { $regex: `${setType(expArr[0])}`, $options: expArr[2] || "" };
 						}
 						break;
-					case "!=regex=":
+					case "=notregex=":
 						{
 							var expArr = exp2.split(/(=)(?=(?:[^"]|"[^"]*")*$)/g);
                         	const regex = new RegExp(expArr[0]);

--- a/test.js
+++ b/test.js
@@ -73,6 +73,13 @@ describe('rsql-mongodb', function () {
         expect(rsqlMongoDB('lastName=regex=do*=mxs')).to.deep.include({ "lastName": { $regex: "do*", $options: "mxs" } });
         expect(rsqlMongoDB('lastName=regex="do=*"=mxs')).to.deep.include({ "lastName": { $regex: "do=*", $options: "mxs" } });
     });
+    it("Test operator Not Like ('!=regex=')", function () {
+        expect(rsqlMongoDB('lastName!=regex=do*')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "" } }});
+        expect(rsqlMongoDB('lastName!=regex=.*oe')).to.deep.include({ "lastName": { $not: { $regex: ".*oe", $options: "" } }});
+        expect(rsqlMongoDB('lastName!=regex=do*=i')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "i" } }});
+        expect(rsqlMongoDB('lastName!=regex=do*=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "mxs" } }});
+        expect(rsqlMongoDB('lastName!=regex="do=*"=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do=*", $options: "mxs" } }});
+    });
     it("Test operator Exists ('=exists=')", function () {
         expect(rsqlMongoDB('childs=exists=true')).to.deep.include({ "childs": { $exists: true } });
         expect(rsqlMongoDB('childs=exists=false')).to.deep.include({ "childs": { $exists: false } });

--- a/test.js
+++ b/test.js
@@ -73,12 +73,12 @@ describe('rsql-mongodb', function () {
         expect(rsqlMongoDB('lastName=regex=do*=mxs')).to.deep.include({ "lastName": { $regex: "do*", $options: "mxs" } });
         expect(rsqlMongoDB('lastName=regex="do=*"=mxs')).to.deep.include({ "lastName": { $regex: "do=*", $options: "mxs" } });
     });
-    it("Test operator Not Like ('!=regex=')", function () {
-        expect(rsqlMongoDB('lastName!=regex=do*')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "" } }});
-        expect(rsqlMongoDB('lastName!=regex=.*oe')).to.deep.include({ "lastName": { $not: { $regex: ".*oe", $options: "" } }});
-        expect(rsqlMongoDB('lastName!=regex=do*=i')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "i" } }});
-        expect(rsqlMongoDB('lastName!=regex=do*=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "mxs" } }});
-        expect(rsqlMongoDB('lastName!=regex="do=*"=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do=*", $options: "mxs" } }});
+    it("Test operator Not Like ('=notregex=')", function () {
+        expect(rsqlMongoDB('lastName=notregex=do*')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "" } }});
+        expect(rsqlMongoDB('lastName=notregex=.*oe')).to.deep.include({ "lastName": { $not: { $regex: ".*oe", $options: "" } }});
+        expect(rsqlMongoDB('lastName=notregex=do*=i')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "i" } }});
+        expect(rsqlMongoDB('lastName=notregex=do*=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do*", $options: "mxs" } }});
+        expect(rsqlMongoDB('lastName=notregex="do=*"=mxs')).to.deep.include({ "lastName": { $not: { $regex: "do=*", $options: "mxs" } }});
     });
     it("Test operator Exists ('=exists=')", function () {
         expect(rsqlMongoDB('childs=exists=true')).to.deep.include({ "childs": { $exists: true } });


### PR DESCRIPTION
I've enhanced the code to support a !=regex= operator based on the existing =regex= operator implementation.

I require this to map my data sorting model to the backend, and therefore, I need this enhancement.

Let me know if you need me to adjust my change. Otherwise, I would appreciate it if we could merge this request and publish a new minor version of rsql-mongodb.